### PR TITLE
chore: upgrade to Node.js 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "the-brand-boost",
       "version": "0.1.0",
       "dependencies": {
-        "@types/node": "20.5.1",
+        "@types/node": "22.0.0",
         "@types/react": "18.2.20",
         "@types/react-dom": "18.2.7",
         "@vercel/analytics": "^1.0.2",
@@ -24,6 +24,9 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.9"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -408,8 +411,8 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "node_modules/@types/prop-types": {
@@ -4278,8 +4281,8 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "@types/node": {
-      "version": "20.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "the-brand-boost",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -9,7 +12,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@types/node": "20.5.1",
+    "@types/node": "22.0.0",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",
     "@vercel/analytics": "^1.0.2",


### PR DESCRIPTION
## Summary
- use Node.js 22 for development
- update Node type definitions to 22.0.0

## Testing
- `npm install` (warned about engine v20 vs required 22)
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965aa14d5483258520217493f4f0c8